### PR TITLE
Parity tooling: MATLAB parser + indexer + summarizer (in-package)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ __pycache__/
 
 # Ignore MATLAB autosave files
 *.asv
+# Parity tooling outputs and references
+reports/
+reference/

--- a/src/smap_python_tools/__init__.py
+++ b/src/smap_python_tools/__init__.py
@@ -1,0 +1,3 @@
+from . import parity
+
+__all__ = ["parity"]

--- a/src/smap_python_tools/parity/__init__.py
+++ b/src/smap_python_tools/parity/__init__.py
@@ -1,0 +1,10 @@
+from .matlab_signature import MatlabSignature, parse_matlab_signature
+from .indexer import build_parity_map
+from .summarizer import summarize_parity_map
+
+__all__ = [
+    "MatlabSignature",
+    "parse_matlab_signature",
+    "build_parity_map",
+    "summarize_parity_map",
+]

--- a/src/smap_python_tools/parity/indexer.py
+++ b/src/smap_python_tools/parity/indexer.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import csv
+import os
+from typing import Iterable, List, Tuple
+
+
+def _matlab_files(root: str) -> Iterable[str]:
+    for dirpath, _, filenames in os.walk(root):
+        for name in filenames:
+            if name.endswith(".m"):
+                yield os.path.join(dirpath, name)
+
+
+def _python_files(root: str) -> Iterable[str]:
+    for dirpath, _, filenames in os.walk(root):
+        for name in filenames:
+            if name.endswith(".py"):
+                yield os.path.join(dirpath, name)
+
+
+def build_parity_map(matlab_root: str, python_root: str, csv_path: str) -> List[Tuple[str, str]]:
+    """Create a parity map CSV linking MATLAB and Python files."""
+
+    rows: List[Tuple[str, str]] = []
+    python_set = {
+        os.path.relpath(p, python_root).replace(os.sep, "/"): p for p in _python_files(python_root)
+    }
+
+    for m in _matlab_files(matlab_root):
+        rel = os.path.relpath(m, matlab_root).replace(os.sep, "/")
+        candidate = rel[:-2] + ".py" if rel.endswith(".m") else rel
+        py = python_set.pop(candidate, "")
+        rows.append((m, py))
+
+    for remaining in python_set.values():
+        rows.append(("", remaining))
+
+    os.makedirs(os.path.dirname(csv_path), exist_ok=True)
+    with open(csv_path, "w", newline="") as fh:
+        writer = csv.writer(fh)
+        writer.writerow(["matlab", "python"])
+        writer.writerows(rows)
+
+    return rows
+
+
+def main() -> None:
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Generate MATLAB/Python parity map")
+    parser.add_argument("matlab_root")
+    parser.add_argument("python_root")
+    parser.add_argument("output", nargs="?", default="reports/parity_map.csv")
+    args = parser.parse_args()
+    build_parity_map(args.matlab_root, args.python_root, args.output)
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry
+    main()

--- a/src/smap_python_tools/parity/matlab_signature.py
+++ b/src/smap_python_tools/parity/matlab_signature.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import List
+
+
+@dataclass
+class MatlabSignature:
+    """Represents a MATLAB function signature."""
+
+    name: str
+    outputs: List[str]
+    inputs: List[str]
+    comments: List[str]
+
+
+_DEF_RE = re.compile(
+    r"^function\s+(?:\[(?P<outs>[^\]]*)\]|(?P<out>[^=\s]+))\s*=\s*(?P<name>\w+)\s*\((?P<ins>[^)]*)\)",
+    re.IGNORECASE,
+)
+_NOOUT_RE = re.compile(
+    r"^function\s+(?P<name>\w+)\s*\((?P<ins>[^)]*)\)",
+    re.IGNORECASE,
+)
+
+
+def parse_matlab_signature(source: str) -> MatlabSignature:
+    """Parse a MATLAB function signature and leading comments from ``source``.
+
+    Parameters
+    ----------
+    source:
+        Text of a MATLAB ``.m`` file.
+    """
+
+    lines = source.splitlines()
+    comments: List[str] = []
+    i = 0
+    while i < len(lines) and lines[i].lstrip().startswith("%"):
+        comments.append(lines[i].lstrip()[1:].strip())
+        i += 1
+
+    func_line = ""
+    while i < len(lines):
+        line = lines[i].strip()
+        if line.startswith("function"):
+            func_line = line
+            break
+        i += 1
+
+    outputs: List[str] = []
+    inputs: List[str] = []
+    name = ""
+
+    m = _DEF_RE.match(func_line)
+    if m:
+        outs = m.group("outs") or m.group("out") or ""
+        name = m.group("name")
+        ins = m.group("ins") or ""
+        outputs = [o.strip() for o in outs.split(",") if o.strip()]
+        inputs = [p.strip() for p in ins.split(",") if p.strip()]
+    else:
+        m = _NOOUT_RE.match(func_line)
+        if m:
+            name = m.group("name")
+            ins = m.group("ins") or ""
+            inputs = [p.strip() for p in ins.split(",") if p.strip()]
+
+    return MatlabSignature(name=name, outputs=outputs, inputs=inputs, comments=comments)

--- a/src/smap_python_tools/parity/summarizer.py
+++ b/src/smap_python_tools/parity/summarizer.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import csv
+from typing import Dict
+
+
+def summarize_parity_map(csv_path: str) -> Dict[str, int]:
+    """Summarize a parity map CSV produced by :mod:`indexer`."""
+
+    counts: Dict[str, int] = {"matched": 0, "matlab_only": 0, "python_only": 0}
+    with open(csv_path, newline="") as fh:
+        reader = csv.DictReader(fh)
+        for row in reader:
+            has_m = bool(row["matlab"].strip())
+            has_p = bool(row["python"].strip())
+            if has_m and has_p:
+                counts["matched"] += 1
+            elif has_m:
+                counts["matlab_only"] += 1
+            elif has_p:
+                counts["python_only"] += 1
+    return counts
+
+
+def main() -> None:
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Summarize a parity map CSV")
+    parser.add_argument("csv_path")
+    args = parser.parse_args()
+    counts = summarize_parity_map(args.csv_path)
+    for key, val in counts.items():
+        print(f"{key}: {val}")
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry
+    main()

--- a/tests/test_parity_tools.py
+++ b/tests/test_parity_tools.py
@@ -1,0 +1,41 @@
+from smap_python_tools.parity import (
+    MatlabSignature,
+    build_parity_map,
+    parse_matlab_signature,
+    summarize_parity_map,
+)
+
+
+def test_parse_matlab_signature_basic():
+    src = "% Leading\n% Comment\nfunction out = foo(in)\n"
+    sig = parse_matlab_signature(src)
+    assert isinstance(sig, MatlabSignature)
+    assert sig.name == "foo"
+    assert sig.outputs == ["out"]
+    assert sig.inputs == ["in"]
+    assert sig.comments == ["Leading", "Comment"]
+
+
+def test_parse_matlab_signature_multiple_outputs():
+    src = "function [a, b] = bar(x, y)\n"
+    sig = parse_matlab_signature(src)
+    assert sig.name == "bar"
+    assert sig.outputs == ["a", "b"]
+    assert sig.inputs == ["x", "y"]
+    assert sig.comments == []
+
+
+def test_index_and_summarize(tmp_path):
+    matlab_root = tmp_path / "matlab"
+    python_root = tmp_path / "python"
+    matlab_root.mkdir()
+    python_root.mkdir()
+
+    (matlab_root / "foo.m").write_text("function y = foo(x)\n")
+    (python_root / "foo.py").write_text("def foo(x):\n    return x\n")
+    (python_root / "bar.py").write_text("def bar():\n    pass\n")
+
+    csv_path = tmp_path / "map.csv"
+    build_parity_map(str(matlab_root), str(python_root), str(csv_path))
+    counts = summarize_parity_map(str(csv_path))
+    assert counts == {"matched": 1, "matlab_only": 0, "python_only": 1}


### PR DESCRIPTION
Summary

- Implemented a new parity module featuring a MatlabSignature dataclass and parser that extracts outputs, inputs, and leading comments from MATLAB functions, enabling structured comparisons with Python counterparts.
- Added an indexer to traverse MATLAB and Python source trees and emit a CSV parity map, and a summarizer to tally matched and unmatched implementations.
- Updated ignore rules for reports and reference directories and generated the initial parity map report, with unit tests covering multiple signature scenarios.

Testing

- ✅ PYTHONPATH=src pytest tests/test_parity_tools.py
- ⚠️ pre-commit not run in Codex Cloud (tool not installed); will run locally/CI.
- (Optional) PYTHONPATH=src python -m smap_python_tools.parity.summarizer reports/parity_map.csv

Notes

- No changes were made under reference/matlab/.

------
https://chatgpt.com/codex/tasks/task_e_68c1a98513f88331850e349764ff0427